### PR TITLE
chore: remove voter balances endpoint

### DIFF
--- a/src/api/delegates.rs
+++ b/src/api/delegates.rs
@@ -63,28 +63,6 @@ impl Delegates {
         self.client.get_with_params(&endpoint, parameters)
     }
 
-    /// Returns the voters of a delegate and their balances
-    ///
-    /// # Example
-    /// ```
-    /// # extern crate serde_json;
-    /// # extern crate arkecosystem_client;
-    ///
-    /// # use serde_json::to_string_pretty;
-    /// # use arkecosystem_client::connection::Connection;
-    ///
-    /// # fn main() {
-    ///   # let client = Connection::new("http://167.114.43.38:4003/api/");
-    ///   let delegate_id = "yo";
-    ///   let voters_balances = client.delegates.voters_balances(&delegate_id).unwrap();
-    ///   println!("{}", to_string_pretty(&voters_balances).unwrap());
-    /// # }
-    /// ```
-    pub fn voters_balances(&self, id: &str) -> Result<Balances> {
-        let endpoint = format!("delegates/{}/voters/balances", id);
-        self.client.get(&endpoint)
-    }
-
     /// Searches the delegates
     ///
     /// # Example

--- a/src/api/delegates.rs
+++ b/src/api/delegates.rs
@@ -2,7 +2,7 @@ use http::client::Client;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 
-use api::models::{Balances, Block, Delegate, Wallet};
+use api::models::{Block, Delegate, Wallet};
 use api::Result;
 
 pub struct Delegates {

--- a/tests/api/delegates_test.rs
+++ b/tests/api/delegates_test.rs
@@ -139,23 +139,6 @@ fn test_voters_params() {
 }
 
 #[test]
-fn test_voters_balances() {
-    let (_mock, body) = mock_http_request("delegates/dummy/voters/balances");
-    {
-        let client = mock_client();
-        let delegate_address = "dummy";
-        let actual = client.delegates.voters_balances(delegate_address).unwrap();
-        let expected: Value = from_str(&body).unwrap();
-
-        let actual_data = actual.data;
-        let expected_data = expected["data"].clone();
-        for (address, balance) in &actual_data {
-            assert_eq!(*balance, expected_data[address].as_u64().unwrap());
-        }
-    }
-}
-
-#[test]
 fn test_search() {
     let (_mock, body) = mock_post_request("delegates/search");
     {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Removes the function to retrieve the voter balances.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Other... Please describe:

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes