### PR TITLE
refactor: remove version argument remains

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -38,7 +38,7 @@ impl Api {
     }
 
     pub fn new_with_client(client: &Client) -> Api {
-        let mut client = client.clone();
+        let client = client.clone();
 
         Api {
             blocks: Blocks::new(client.clone()),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,17 +33,12 @@ pub struct Api {
 }
 
 impl Api {
-    fn version() -> &'static str {
-        "2"
-    }
-
     pub fn new(host: &str) -> Api {
         Api::new_with_client(&Client::new(host))
     }
 
     pub fn new_with_client(client: &Client) -> Api {
         let mut client = client.clone();
-        client.set_version(&Api::version());
 
         Api {
             blocks: Blocks::new(client.clone()),

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -1,33 +1,33 @@
-use std::any::Any;
 use std::collections::hash_map::Values;
 use std::collections::HashMap;
 use Connection;
+use std::rc::Rc;
 
 #[derive(Default)]
-pub struct Manager<'a> {
-    connections: HashMap<String, &'a Any>,
+pub struct Manager{
+    connections: HashMap<String, Rc<Connection>>,
     default_connection: String,
 }
 
-impl<'a> Manager<'a> {
-    pub fn new() -> Manager<'a> {
+impl Manager {
+    pub fn new() -> Manager {
         Manager {
-            connections: HashMap::<String, &'a Any>::new(),
+            connections: HashMap::new(),
             default_connection: String::from("main"),
         }
     }
 
-    pub fn connect(&mut self, connection: &'a Connection) -> Result<(), &str> {
+    pub fn connect(&mut self, connection: Connection) -> Result<(), &str> {
         let default_connection = &self.get_default_connection();
         self.connect_as(connection, default_connection)
     }
 
-    pub fn connect_as(&mut self, connection: &'a Connection, name: &str) -> Result<(), &str> {
+    pub fn connect_as(&mut self, connection: Connection, name: &str) -> Result<(), &str> {
         if self.connections.contains_key(name) {
             return Err("Connection already exists.");
         }
 
-        self.connections.insert(name.to_owned(), connection);
+        self.connections.insert(name.to_owned(), Rc::new(connection));
         Ok(())
     }
 
@@ -39,18 +39,18 @@ impl<'a> Manager<'a> {
         }
     }
 
-    pub fn connection(&self) -> Option<&'a Connection> {
+    pub fn connection(&self) -> Option<Rc<Connection>> {
         let connection_name = self.get_default_connection();
         if let Some(conn) = self.connections.get(&connection_name) {
-            return conn.downcast_ref();
+            return Some(conn.clone());
         }
 
         None
     }
 
-    pub fn connection_by_name(&self, name: &str) -> Option<&'a Connection> {
+    pub fn connection_by_name(&self, name: &str) -> Option<Rc<Connection>> {
         if let Some(conn) = self.connections.get(name) {
-            return conn.downcast_ref();
+            return Some(conn.clone());
         }
 
         None
@@ -64,7 +64,7 @@ impl<'a> Manager<'a> {
         self.default_connection = name.to_owned();
     }
 
-    pub fn connections(&self) -> Values<String, &'a Any> {
+    pub fn connections(&self) -> Values<String, Rc<Connection>> {
         self.connections.values()
     }
 }

--- a/src/connection/manager.rs
+++ b/src/connection/manager.rs
@@ -1,10 +1,10 @@
 use std::collections::hash_map::Values;
 use std::collections::HashMap;
-use Connection;
 use std::rc::Rc;
+use Connection;
 
 #[derive(Default)]
-pub struct Manager{
+pub struct Manager {
     connections: HashMap<String, Rc<Connection>>,
     default_connection: String,
 }
@@ -27,7 +27,8 @@ impl Manager {
             return Err("Connection already exists.");
         }
 
-        self.connections.insert(name.to_owned(), Rc::new(connection));
+        self.connections
+            .insert(name.to_owned(), Rc::new(connection));
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Api(ref _err) => None,
             Error::ReqwestHttp(ref err) => Some(err),

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -27,11 +27,6 @@ impl Client {
         }
     }
 
-    pub fn set_version(&mut self, version: &'static str) {
-        self.headers
-            .insert("API-Version", HeaderValue::from_static(version));
-    }
-
     pub fn get<T: DeserializeOwned>(&self, endpoint: &str) -> Result<T> {
         let url = Url::parse(&format!("{}{}", self.host, endpoint))?;
         self.internal_get(&url)

--- a/tests/connection/manager_test.rs
+++ b/tests/connection/manager_test.rs
@@ -7,7 +7,7 @@ fn test_create_connection() {
     let conn = Connection::new("test");
     let mut manager = Manager::new();
 
-    assert!(manager.connect(&conn).is_ok());
+    assert!(manager.connect(conn).is_ok());
     assert_eq!(manager.connections().count(), 1);
 }
 
@@ -17,8 +17,8 @@ fn test_create_existing_connection() {
     let conn2 = Connection::new("test2");
 
     let mut manager = Manager::new();
-    assert!(manager.connect(&conn1).is_ok());
-    assert!(manager.connect(&conn2).is_err());
+    assert!(manager.connect(conn1).is_ok());
+    assert!(manager.connect(conn2).is_err());
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn test_remove_connection() {
     let conn = Connection::new("test1");
     let mut manager = Manager::new();
 
-    assert!(manager.connect(&conn).is_ok());
+    assert!(manager.connect(conn).is_ok());
     manager.disconnect("");
     assert_eq!(manager.connections().count(), 0);
 }
@@ -36,7 +36,7 @@ fn test_get_connection() {
     let conn = Connection::new("test1");
     let mut manager = Manager::new();
 
-    assert!(manager.connect(&conn).is_ok());
+    assert!(manager.connect(conn).is_ok());
     let default_conn = manager.connection();
     assert!(default_conn.is_some());
 }
@@ -70,8 +70,8 @@ fn test_get_all_connections() {
     let conn2 = Connection::new("test3");
     let mut manager = Manager::new();
 
-    assert!(manager.connect_as(&conn1, "test1").is_ok());
-    assert!(manager.connect_as(&conn2, "test3").is_ok());
+    assert!(manager.connect_as(conn1, "test1").is_ok());
+    assert!(manager.connect_as(conn2, "test3").is_ok());
 
     let connections = manager.connections();
     assert_eq!(connections.count(), 2);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Remove all code that related to setting an API-Version as Core 2.5 will only serve the v2 API.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
